### PR TITLE
Add newlines to error messages

### DIFF
--- a/autoformat.html
+++ b/autoformat.html
@@ -10,9 +10,9 @@
             function auto_format(line_length) {
                 let line_length_arg = "max-line-length="+line_length.toString()
                 var model = stanc("test_model",$("#model").val(), ["auto-format", line_length_arg]);
-                    
+
                 if(model.errors) {
-                    $("#error").html(model.errors[1]);
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
                     $("#result").html("");
                 } else {
                     $("#result").html(Prism.highlight(model.result, Prism.languages.stan, 'stan'));
@@ -29,7 +29,7 @@
                 }
                 let model = "dHJhbnNmb3JtZWQgZGF0YXsKcmVhbCBtID0gMDsKZm9yKGkgaW4gMTo1KQp7Cm0gKz0gMS4xKiBpOwp9Cn0KcGFyYW1ldGVycyB7CnJlYWwKeTsgLy8gY29tbWVudAp9Cm1vZGVsIHsKeQp%2BIHN0ZF9ub3JtYWwoKTsKfQ%3D%3D"
                 if (model_url) {
-                    model = model_url   
+                    model = model_url
                 }
                 $("#model").val(atob(decodeURIComponent(model)))
                 $("#model").focus(function () {
@@ -37,7 +37,7 @@
                 })
                 $("#compile").click(function() {
                     line_length = $("#line-length").val()
-                    auto_format(line_length);                    
+                    auto_format(line_length);
                 });
                 auto_format(line_length);
 

--- a/canonicalizer.html
+++ b/canonicalizer.html
@@ -30,9 +30,9 @@
                     args.push("canonicalize="+canonicalize_modes)
                 }
                 var model = stanc("test_model",$("#model").val(), args);
-                    
+
                 if(model.errors) {
-                    $("#error").html(model.errors[1]);
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
                     $("#result").html("");
                 } else {
                     $("#result").html(Prism.highlight(model.result, Prism.languages.stan, 'stan'));
@@ -49,7 +49,7 @@
                 }
                 let model = "cGFyYW1ldGVycyB7CiAgcmVhbCB5WzVdOwogIHJlYWwgeDsKfQptb2RlbCB7CiAgZm9yIChpIGluIDEgOiA1KSB7CiAgICB0YXJnZXQgKz0gbm9ybWFsX2xvZyh4LCB5W2ldLCAoMC41ICsgMSkpOwogIH0KfQ%3D%3D"
                 if (model_url) {
-                    model = model_url   
+                    model = model_url
                 }
                 $("#model").val(atob(decodeURIComponent(model)))
                 $("#model").focus(function () {
@@ -57,7 +57,7 @@
                 })
                 $("#compile").click(function() {
                     line_length = $("#line-length").val()
-                    canonicalizer(line_length);                    
+                    canonicalizer(line_length);
                 });
                 canonicalizer(line_length);
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             var model = stanc("test_model", $("#model").val());
 
             if (model.errors) {
-                $("#error").html(model.errors[1]);
+                $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
                 $("#result").html("");
             } else {
                 $("#result").html(Prism.highlight(model.result, Prism.languages.cpp, 'cpp'));
@@ -20,7 +20,7 @@
             let model_url = GetURLParameter("model")
             let model = "cGFyYW1ldGVycyB7CiAgICByZWFsIHk7Cn0KbW9kZWwgewogICAgeSB%2BIHN0ZF9ub3JtYWwoKTsKfQ%3D%3D"
             if (model_url) {
-                model = model_url   
+                model = model_url
             }
             $("#model").val(atob(decodeURIComponent(model)))
             $("#model").focus(function () {
@@ -58,7 +58,7 @@
 
             <p id="saved"></p>
             </div>
-        </div>     
+        </div>
         <div id="url-box" class="error-box"></div>
         <div id="error" class="error-box"></div>
         <pre><code id = "result" class="language-cpp"></code></pre>

--- a/optimization.html
+++ b/optimization.html
@@ -17,9 +17,9 @@
                     opt = "0experimental"
                 }
                 var model_opt = stanc("test_model",$("#model").val(), [opt, "debug-optimized-mir-pretty"]);
-                    
+
                 if(model_opt.errors) {
-                    $("#error").html(model_opt.errors[1]);
+                    $("#error").html(model_opt.errors[1].replace(/\n/g, "<br/>"));
                     $("#result1").html("");
                 } else {
                     $("#result1").html(Prism.highlight(model_opt.result, Prism.languages.stan, 'cpp'));
@@ -27,9 +27,9 @@
                 }
 
                 var model_no_opt = stanc("test_model",$("#model").val(), ["debug-optimized-mir-pretty"]);
-                
+
                 if(model_no_opt.errors) {
-                    $("#error").html(model_no_opt.errors[1]);
+                    $("#error").html(model_no_opt.errors[1].replace(/\n/g, "<br/>"));
                     $("#result2").html("");
                 } else {
                     $("#result2").html(Prism.highlight(model_no_opt.result, Prism.languages.stan, 'cpp'));
@@ -40,14 +40,14 @@
                 let model_url = GetURLParameter("model")
                 let model = "ZnVuY3Rpb25zIHsKICByZWFsIGZvbyhkYXRhIGFycmF5WyxdIHJlYWwgeCwgYXJyYXlbXSBpbnQgeSwgdmVjdG9yIGJldGEsIGludCBOLCBpbnQgSykgewogICAgbWF0cml4W04sIEtdIG14ID0gdG9fbWF0cml4KHgpOwogICAgcmV0dXJuIGJlcm5vdWxsaV9sb2dpdF9scG1mKHkgfCBteCAqIGJldGEpOwogIH0KfQpwYXJhbWV0ZXJzIHsKICByZWFsIHk7Cn0KbW9kZWwgewogIHkgfiBzdGRfbm9ybWFsKCk7Cn0%3D"
                 if (model_url) {
-                    model = model_url   
+                    model = model_url
                 }
                 $("#model").val(atob(decodeURIComponent(model)))
                 $("#model").focus(function () {
                     $("#url-box").html("");
                 })
                 $("#compile").click(function() {
-                    optimization();                    
+                    optimization();
                 });
                 optimization();
 

--- a/pedantic.html
+++ b/pedantic.html
@@ -10,7 +10,7 @@
             function pedantic_check() {
                 var model = stanc("test_model",$("#model").val(), ["warn-pedantic", "filename-in-msg=demo-model"]);
                 if(model.errors) {
-                    $("#error").html(model.errors[1]);
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
                     $("#result").html("");
                 } else if (model.warnings) {
                     var content = ""
@@ -20,12 +20,12 @@
                     $("#error").html(content);
                 }
             }
-            
+
             $(document).ready(function(){
                 let model_url = GetURLParameter("model")
                 let model = "cGFyYW1ldGVycyB7CiAgcmVhbCB5Owp9Cm1vZGVsIHsKICB5IH4gbm9ybWFsKDAsIDEwMDApOwogIHkgfiBub3JtYWwoMCwgMTApOwp9"
                 if (model_url) {
-                    model = model_url   
+                    model = model_url
                 }
                 $("#model").val(atob(decodeURIComponent(model)))
                 $("#model").focus(function () {


### PR DESCRIPTION
This makes it so the newer error messages in stancjs render properly:

![image](https://user-images.githubusercontent.com/31640292/168149714-10fe607b-76b9-4e2e-bdc1-4297e6170386.png)
