### PR TITLE
Also fix spacing

### DIFF
--- a/autoformat.html
+++ b/autoformat.html
@@ -12,7 +12,7 @@
                 var model = stanc("test_model",$("#model").val(), ["auto-format", line_length_arg]);
 
                 if(model.errors) {
-                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                     $("#result").html("");
                 } else {
                     $("#result").html(Prism.highlight(model.result, Prism.languages.stan, 'stan'));

--- a/canonicalizer.html
+++ b/canonicalizer.html
@@ -32,7 +32,7 @@
                 var model = stanc("test_model",$("#model").val(), args);
 
                 if(model.errors) {
-                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                     $("#result").html("");
                 } else {
                     $("#result").html(Prism.highlight(model.result, Prism.languages.stan, 'stan'));

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
             var model = stanc("test_model", $("#model").val());
 
             if (model.errors) {
-                $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
+                $("#error").html(model.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                 $("#result").html("");
             } else {
                 $("#result").html(Prism.highlight(model.result, Prism.languages.cpp, 'cpp'));
@@ -60,7 +60,7 @@
             </div>
         </div>
         <div id="url-box" class="error-box"></div>
-        <div id="error" class="error-box"></div>
+        <div id="error" class="error-box" style="white-space: pre-line;"></div>
         <pre><code id = "result" class="language-cpp"></code></pre>
     </body>
 </html>

--- a/optimization.html
+++ b/optimization.html
@@ -19,7 +19,7 @@
                 var model_opt = stanc("test_model",$("#model").val(), [opt, "debug-optimized-mir-pretty"]);
 
                 if(model_opt.errors) {
-                    $("#error").html(model_opt.errors[1].replace(/\n/g, "<br/>"));
+                    $("#error").html(model_opt.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                     $("#result1").html("");
                 } else {
                     $("#result1").html(Prism.highlight(model_opt.result, Prism.languages.stan, 'cpp'));
@@ -29,7 +29,7 @@
                 var model_no_opt = stanc("test_model",$("#model").val(), ["debug-optimized-mir-pretty"]);
 
                 if(model_no_opt.errors) {
-                    $("#error").html(model_no_opt.errors[1].replace(/\n/g, "<br/>"));
+                    $("#error").html(model_no_opt.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                     $("#result2").html("");
                 } else {
                     $("#result2").html(Prism.highlight(model_no_opt.result, Prism.languages.stan, 'cpp'));

--- a/pedantic.html
+++ b/pedantic.html
@@ -10,7 +10,7 @@
             function pedantic_check() {
                 var model = stanc("test_model",$("#model").val(), ["warn-pedantic", "filename-in-msg=demo-model"]);
                 if(model.errors) {
-                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>"));
+                    $("#error").html(model.errors[1].replace(/\n/g, "<br/>").replace(/\s/g, '&nbsp;'));
                     $("#result").html("");
                 } else if (model.warnings) {
                     var content = ""


### PR DESCRIPTION
Sorry @rok-cesnovar, didn't catch this before merging. Now the `^` is also in the correct place:
![image](https://user-images.githubusercontent.com/31640292/168155668-1b5bd009-8000-4c05-8346-563c30981830.png)
